### PR TITLE
make sure configure requires is correct

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,6 +11,7 @@ version = 0.001
 
 ; https://code.google.com/p/pdf2json/downloads/list
 [Alien]
+:version = 0.023
 repo = file:inc
 name = pdf2json
 bins = pdf2json


### PR DESCRIPTION
This requires a version of the [Alien] plugin that will ensure that Alien::Base::ModuleBuild is specified as configure_requires instead of AB.  For rationale please see https://github.com/Perl5-Alien/Alien-Base/issues/157
